### PR TITLE
Removed calls to deprecated items, other small updates.

### DIFF
--- a/src/stem.rs
+++ b/src/stem.rs
@@ -1,8 +1,8 @@
-use std::ascii;
-use std::ascii::Ascii;
-use std::vec::Vec;
+#[cfg(test)] extern crate test;
 
-/// Member b is a vector of std::ascii::Ascii holding a word to be stemmed.
+use std::borrow::ToOwned;
+
+/// Member b is a vector of bytes holding a word to be stemmed.
 /// The letters are in b[0], b[1] ... ending at b[z->k]. Member k is readjusted
 /// downwards as the stemming progresses. Zero termination is not in fact used
 /// in the algorithm.
@@ -17,40 +17,45 @@ use std::vec::Vec;
 ///     let res = stem::get(b);
 ///     assert_eq!(res, Ok("pencil".to_string()));
 ///
-pub struct Stemmer {
-    b: Vec<ascii::Ascii>,
+struct Stemmer {
+    b: Vec<u8>,
     k: uint,
-    j: uint,
+    j: uint
 }
 
 impl Stemmer {
-    pub fn new(word: &str) -> Result<Stemmer, &str> {
+    fn new(word: &str) -> Result<Stemmer, &str> {
         if !word.is_ascii() {
             Err("Only support English words with ASCII characters")
         } else {
-            let b = unsafe { word.to_ascii_nocheck().to_lowercase() };
+            let b: Vec<u8> = unsafe { 
+                word.to_ascii_nocheck()
+                    .iter()
+                    .map(|c| c.to_lowercase().as_byte())
+                    .collect()
+            };
             let k = b.len();
             Ok(Stemmer {
                 b: b,
                 k: k,
-                j: 0,
+                j: 0
             })
         }
     }
 
     /// stem.is_consonant(i) is true <=> stem[i] is a consonant
-    pub fn is_consonant(&self, i: uint) -> bool {
-        match self.b[i].to_char() {
-            'a' | 'e' | 'i' | 'o' | 'u' => false,
-            'y' => if i == 0 {
+    #[inline]
+    fn is_consonant(&self, i: uint) -> bool {
+        match self.b[i] {
+            b'a' | b'e' | b'i' | b'o' | b'u' => false,
+            b'y' => if i == 0 {
                 true
             } else {
                 !self.is_consonant(i - 1)
             },
-            _ => true,
+            _ => true
         }
     }
-
 
     /// stem.measure() measures the number of consonant sequences in [0, j).
     /// if c is a consonant sequence and v a vowel sequence, and <..> indicates
@@ -63,7 +68,7 @@ impl Stemmer {
     ///    <c>vcvcvc<v> gives 3
     ///    ....
     /// ~~~
-    pub fn measure(&self) -> uint {
+    fn measure(&self) -> uint {
         let mut n = 0u;
         let mut i = 0u;
         let j = self.j;
@@ -91,17 +96,18 @@ impl Stemmer {
     }
 
     /// stem.has_vowel() is TRUE <=> [0, j-1) contains a vowel
-    pub fn has_vowel(&self) -> bool {
+    fn has_vowel(&self) -> bool {
         for i in range(0, self.j) {
             if !self.is_consonant(i) {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     /// stem.double_consonant(i) is TRUE <=> i,(i-1) contain a double consonant.
-    pub fn double_consonant(&self, i: uint) -> bool {
+    #[inline]
+    fn double_consonant(&self, i: uint) -> bool {
         if i < 1 {
             false
         } else if self.b[i] != self.b[i - 1] {
@@ -119,43 +125,50 @@ impl Stemmer {
     ///    cav(e), lov(e), hop(e), crim(e), but
     ///    snow, box, tray.
     /// ~~~
-    pub fn cvc(&self, i: uint) -> bool {
-        if i < 2 || !self.is_consonant(i) || self.is_consonant(i - 1)
-            || !self.is_consonant(i - 2) { return false }
-        match self.b[i].to_char() {
-            'w' | 'x' | 'y' => false,
-            _ => true,
+    fn cvc(&self, i: uint) -> bool {
+        if i < 2 
+            || !self.is_consonant(i) 
+            || self.is_consonant(i - 1)
+            || !self.is_consonant(i - 2) 
+        {
+            false
+        } else {
+            match self.b[i] {
+                b'w' | b'x' | b'y' => false,
+                _ => true
+            }
         }
     }
 
     /// stem.ends(s) is true <=> [0, k) ends with the string s.
-    pub fn ends(&mut self, s: &str) -> bool {
-        let s = s.as_bytes();
+    fn ends(&mut self, _s: &str) -> bool {
+        let s = _s.as_bytes();
         let len = s.len();
-        let k = self.k;
-        if s[len - 1] != self.b[k-1].to_byte() { return false } /* tiny speed-up */
-        if len > k { return false }
-        let mut iter = s.iter();
-        for ac in self.b.slice(k - len, k).iter() {
-            if ac.to_byte() != *iter.next().unwrap() { return false }
+        if len > self.k {
+            false
+        } else {
+            if self.b.slice(self.k - len, self.k) == s {
+                self.j = self.k - len;
+                true
+            } else {
+                false
+            }
         }
-        self.j = k - len;
-        return true;
     }
 
     /// stem.setto(s) sets [j,k) to the characters in the string s,
     /// readjusting k.
     fn set_to(&mut self, s: &str) {
         let s = s.as_bytes();
-        let length = s.len();
-        let j = self.j;
-        for i in range(0, length) {
-            self.b.as_mut_slice()[j + i] = s[i].to_ascii();
+        let len = s.len();
+        for i in range(0, len) {
+            self.b.as_mut_slice()[self.j + i] = s[i];
         }
-        self.k = j + length;
+        self.k = self.j + len;
     }
 
     /// self.replace(s) is used further down.
+    #[inline]
     fn r(&mut self, s: &str) {
         if self.measure() > 0 {
             self.set_to(s);
@@ -183,13 +196,13 @@ impl Stemmer {
     ///
     ///     meetings  ->  meet
     /// ~~~~
-    pub fn step1ab(&mut self) {
-        if self.b[self.k - 1].to_char() == 's' {
+    fn step1ab(&mut self) {
+        if self.b[self.k - 1] == b's' {
             if self.ends("sses") {
                 self.k -= 2;
             } else if self.ends("ies") {
                 self.set_to("i");
-            } else if self.b[self.k - 2].to_char() != 's' {
+            } else if self.b[self.k - 2] != b's' {
                 self.k -= 1;
             }
         }
@@ -205,9 +218,9 @@ impl Stemmer {
                 self.set_to("ize");
             } else if self.double_consonant(self.k - 1) {
                 self.k -= 1;
-                match self.b[self.k - 1].to_char() {
-                    'l' | 's' | 'z' => self.k += 1,
-                    _ => (),
+                match self.b[self.k - 1] {
+                    b'l' | b's' | b'z' => self.k += 1,
+                    _ => ()
                 }
             } else if self.measure() == 1 && self.cvc(self.k - 1) {
                 self.set_to("e");
@@ -216,160 +229,162 @@ impl Stemmer {
     }
 
     /// stem.step1c() turns terminal y to i when there is another vowel in the stem.
-    pub fn step1c(&mut self) {
-       if self.ends("y") && self.has_vowel() {
-           self.b.as_mut_slice()[self.k-1] = 'i'.to_ascii();
+    fn step1c(&mut self) {
+        if self.ends("y") && self.has_vowel() {
+           self.b.as_mut_slice()[self.k - 1] = b'i';
         }
     }
 
     /// stem.step2() maps double suffices to single ones. so -ization ( = -ize
     /// plus -ation) maps to -ize etc. note that the string before the suffix
     /// must give m(z) > 0.
-    pub fn step2(&mut self) {
-        match self.b[self.k-2].to_char() {
-            'a' => {
+    fn step2(&mut self) {
+        match self.b[self.k - 2] {
+            b'a' => {
                 if self.ends("ational") { self.r("ate"); return }
                 if self.ends("tional") { self.r("tion"); return }
-            },
-            'c' => {
+            }
+            b'c' => {
                 if self.ends("enci") { self.r("ence"); return }
                 if self.ends("anci") { self.r("ance"); return }
-            },
-            'e' => if self.ends("izer") { self.r("ize"); return },
-            'l' => {
+            }
+            b'e' => if self.ends("izer") { self.r("ize"); return },
+            b'l' => {
                 if self.ends("bli") { self.r("ble"); return } /*-DEPARTURE-*/
 
              /* To match the published algorithm, replace this line with
                 'l' => {
                     if self.ends("abli") { self.r("able"); return } */
 
-                 if self.ends("alli") { self.r("al"); return }
-                 if self.ends("entli") { self.r("ent"); return }
-                 if self.ends("eli") { self.r("e"); return }
-                 if self.ends("ousli") { self.r("ous"); return }
-            },
-            'o' => {
+                if self.ends("alli") { self.r("al"); return }
+                if self.ends("entli") { self.r("ent"); return }
+                if self.ends("eli") { self.r("e"); return }
+                if self.ends("ousli") { self.r("ous"); return }
+            }
+            b'o' => {
                 if self.ends("ization") { self.r("ize"); return }
                 if self.ends("ation") { self.r("ate"); return }
                 if self.ends("ator") { self.r("ate"); return }
-            },
-            's' => {
+            }
+            b's' => {
                 if self.ends("alism") { self.r("al"); return }
                 if self.ends("iveness") { self.r("ive"); return }
                 if self.ends("fulness") { self.r("ful"); return }
                 if self.ends("ousness") { self.r("ous"); return }
-            },
-            't' => {
+            }
+            b't' => {
                 if self.ends("aliti") { self.r("al"); return }
                 if self.ends("iviti") { self.r("ive"); return }
                 if self.ends("biliti") { self.r("ble"); return }
-            },
-            'g' => if self.ends("logi") { self.r("log"); return }, /*-DEPARTURE-*/
+            }
+            b'g' => if self.ends("logi") { self.r("log"); return }, /*-DEPARTURE-*/
              /* To match the published algorithm, delete this line */
-            _ => (),
+            _ => ()
         }
     }
 
     /// stem.step3() deals with -ic-, -full, -ness etc. similar strategy to step2.
-    pub fn step3(&mut self) {
-        match self.b[self.k-1].to_char() {
-            'e' => {
+    fn step3(&mut self) {
+        match self.b[self.k - 1] {
+            b'e' => {
                 if self.ends("icate") { self.r("ic"); return }
                 if self.ends("ative") { self.r(""); return }
                 if self.ends("alize") { self.r("al"); return }
-            },
-            'i' => if self.ends("iciti") { self.r("ic"); return },
-            'l' => {
+            }
+            b'i' => if self.ends("iciti") { self.r("ic"); return },
+            b'l' => {
                 if self.ends("ical") { self.r("ic"); return }
                 if self.ends("ful") { self.r(""); return }
-            },
-            's' => if self.ends("ness") { self.r(""); return },
-            _ => (),
+            }
+            b's' => if self.ends("ness") { self.r(""); return },
+            _ => ()
         }
     }
 
     /// stem.step4() takes off -ant, -ence etc., in context <c>vcvc<v>.
-    pub fn step4(&mut self) {
-        match self.b[self.k-2].to_char() {
-            'a' => {
+    fn step4(&mut self) {
+        match self.b[self.k - 2] {
+            b'a' => {
                 if self.ends("al") {}
                 else { return }
             }
-            'c' => {
+            b'c' => {
                 if self.ends("ance") {}
                 else if self.ends("ence") {}
                 else { return }
-            },
-            'e' => {
+            }
+            b'e' => {
                 if self.ends("er") {}
                 else { return }
             }
-            'i' => {
+            b'i' => {
                 if self.ends("ic") {}
                 else { return }
-            },
-            'l' => {
+            }
+            b'l' => {
                 if self.ends("able") {}
                 else if self.ends("ible") {}
                 else { return }
-            },
-            'n' => {
+            }
+            b'n' => {
                 if self.ends("ant") {}
                 else if self.ends("ement") {}
                 else if self.ends("ment") {}
                 else if self.ends("ent") {}
                 else { return }
-            },
-            'o' => {
-                if self.ends("ion")
-                    && (self.b[self.j-1].to_char() == 's' || self.b[self.j-1].to_char() == 't') {}
+            }
+            b'o' => {
+                if self.ends("ion") && 
+                    (self.b[self.j - 1] == b's' || self.b[self.j - 1] == b't') {}
                 else if self.ends("ou") {}
                 else { return }
                 /* takes care of -ous */
-            },
-            's' => {
+            }
+            b's' => {
                 if self.ends("ism") {}
                 else { return }
-            },
-            't' => {
+            }
+            b't' => {
                 if self.ends("ate") {}
                 else if self.ends("iti") {}
                 else { return }
-            },
-            'u' => {
+            }
+            b'u' => {
                 if self.ends("ous") {}
                 else { return }
-            },
-            'v' => {
+            }
+            b'v' => {
                 if self.ends("ive") {}
                 else { return }
-            },
-            'z' => {
+            }
+            b'z' => {
                 if self.ends("ize") {}
                 else { return }
-            },
-            _ => return,
+            }
+            _ => return
         }
         if self.measure() > 1 { self.k = self.j }
     }
 
-    /// stem.step5() removes a final -e if self.measure() > 1, and changes -ll
+    /// stem.step5() removes a final -e if self.measure() > 0, and changes -ll
     /// to -l if self.measure() > 1.
-    pub fn step5(&mut self) {
-       self.j = self.k;
-       if self.b[self.k - 1].to_char() == 'e' {
-           let a = self.measure();
-           if a > 1 || a == 1 && !self.cvc(self.k - 2) { self.k -= 1 }
-       }
-       if self.b[self.k-1].to_char() == 'l'
-           && self.double_consonant(self.k-1) && self.measure() > 1 {
-           self.k-=1;
-       }
+    fn step5(&mut self) {
+        self.j = self.k;
+        if self.b[self.k - 1] == b'e' {
+            let a = self.measure();
+            if a > 1 || a == 1 && !self.cvc(self.k - 2) { self.k -= 1 }
+        }
+        if self.b[self.k - 1] == b'l' && 
+            self.double_consonant(self.k - 1) && 
+            self.measure() > 1 
+        {
+            self.k -= 1;
+        }
     }
 
-    pub fn get(&self) -> String {
-        let borrowed = self.b.slice_to(self.k);
-        borrowed.as_str_ascii().into_string()
+    #[inline]
+    fn get(&self) -> String {
+        unsafe { String::from_raw_buf_len(self.b.slice_to(self.k).as_ptr(), self.k) }
     }
 }
 
@@ -389,42 +404,61 @@ pub fn get(word: &str) -> Result<String, &str> {
             Err(e) => Err(e),
         }
     } else {
-        Ok(word.into_string())
+        Ok(word.to_owned())
     }
 }
 
 #[cfg(test)]
-mod test {
-    use std::io::File;
-    use std::io::BufferedReader;
-    use std::path;
-
+mod test_stem {
     use super::get;
+    use test::Bencher;
+
+    pub static INPUT: &'static str  = include_str!("../test-data/voc.txt");
+    pub static RESULT: &'static str = include_str!("../test-data/output.txt");
+
+    fn test_loop<
+        's, 
+        I0: Iterator<T>, 
+        I1: Iterator<T>, 
+        T: Deref<str>>(
+        tests: I0, 
+        results: I1
+    ) {
+        for (test, expect) in tests.zip(results) {
+            let stemmed = get(test.trim_right_chars('\r'));
+
+            assert!(stemmed.is_ok(), "[FAILED] Expected stem for '{}'", test.trim_right_chars('\r'));
+            assert_eq!(stemmed.unwrap().trim_right_chars('\r'), expect.trim_right_chars('\r'));
+        }
+    }
 
     #[test]
     fn lexicon() {
-        let input = File::open(&path::Path::new("test-data/voc.txt")).unwrap();
-        let result = File::open(&path::Path::new("test-data/output.txt")).unwrap();
-        let mut input_reader = BufferedReader::new(input);
-        let mut result_reader = BufferedReader::new(result);
-        loop {
-            match input_reader.read_line() {
-                Ok(word) => match get(word.as_slice().trim()) {
-                    Ok(stem) => {
-                        match result_reader.read_line() {
-                            Ok(answer) => if answer.as_slice().trim() != stem.as_slice() {
-                                panic!("\n[FAILED] '{:s}' != '{:s}'", stem, answer);
-                            } else {
-                                print!(".");
-                            },
-                            Err(_) => break,
-                        }
-                    },
-                    Err(e) => panic!("\n[FAILED] Cannot get stem for '{:s}': {:s}", word, e),
-                },
-                Err(_) => break,
+        let input_s = INPUT.split('\n');
+        let result_s = RESULT.split('\n');
+
+        test_loop(input_s, result_s);
+    }
+
+    #[bench]
+    fn lexicon_bench(b: &mut Bencher) {
+        let input_v: Vec<&str> = INPUT.split('\n').collect();
+
+        b.iter(|| {
+            for t in input_v.iter() {
+                let stemmed = get(t.trim_right_chars('\r'));
+
+                assert!(stemmed.is_ok());
             }
-        }
-        println!("");
+        });
+    }
+
+    #[bench]
+    fn single_bench(b: &mut Bencher) {
+        b.iter(|| {
+            let stemmed = get("testing");
+
+            assert!(stemmed.is_ok());
+        });
     }
 }


### PR DESCRIPTION
Hey, I made some small changes to your library and updated some of the code to use non-deprecated items. Here's a run down of what I did:

* Stemmer uses bytes instead of ascii - gets rid of all the conversions (`to_char`, `as_ascii`, etc.), and makes the code more readable in my opinion.
* Updated tests to make them use assertions, added benchmarks.
* Attempted to make code more idiomatic rust (probably still needs work though).
* Replaced calls to deprecated items -- removed all warnings compiling with the most recent nightly build.
* Removed public visibility on Stemmer (made more sense to not expose it publicly to me)
* Attempted to add `inline` directive to some functions to improve performance.

Running the newly added bench marks, there seems to be a slight improvement in performance:

Old code: 
```
running 3 tests
test test_stem::lexicon ... ignored
test test_stem::lexicon_bench ... bench:   4680445 ns/iter (+/- 88446)
test test_stem::single_bench  ... bench:       180 ns/iter (+/- 7)
```

My pull:
```
running 3 tests
test test_stem::lexicon ... ignored
test test_stem::lexicon_bench ... bench:   4170162 ns/iter (+/- 82477)
test test_stem::single_bench  ... bench:       132 ns/iter (+/- 7)
```
